### PR TITLE
Add Fast-dLLM++ (Fréchet Profile Decoding)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1105,6 +1105,7 @@ Super Data Learners: [Diffusion Language Models are Super Data Learners](https:/
 
 
 ## Inference Optimization
+- **Fast-dLLM++: Fréchet Profile Decoding for Faster Diffusion LLM Inference** (2026) [[arXiv](https://arxiv.org/abs/2606.02955)] [[Code](https://github.com/Ringo-Star/FastdLLM_plusplus)] [[Project Page](https://ringo-star.github.io/projectpage_frechet/)]
 [15 May 2026] [PSD: Pushing the Pareto Frontier of Diffusion LLMs via Parallel Speculative Decoding](https://arxiv.org/abs/2605.15609)<br>
 [![arXiv](https://img.shields.io/badge/arXiv-b31b1b.svg)](https://arxiv.org/abs/2605.15609)
 


### PR DESCRIPTION
Adds **Fast-dLLM++: Fréchet Profile Decoding for Faster Diffusion LLM Inference** (arXiv 2606.02955).

- Paper: https://arxiv.org/abs/2606.02955
- Code: https://github.com/Ringo-Star/FastdLLM_plusplus
- Project page: https://ringo-star.github.io/projectpage_frechet/

Training-free extension of Fast-dLLM: profile-aware (Fréchet) parallel decoding for masked diffusion LLMs; drop-in replacement for the threshold/factor selector, up to 37% higher throughput at comparable accuracy on GSM8K/MATH/HumanEval/MBPP with LLaDA-8B. Placed in the most relevant section (add).