### PR TITLE
Add DiffusionGemma Explained (ML@Berkeley blog post)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1888,6 +1888,8 @@ Super Data Learners: [Diffusion Language Models are Super Data Learners](https:/
 [Mercury](https://www.inceptionlabs.ai/introducing-mercury) 
 [![Arxiv](https://img.shields.io/badge/arXiv-b31b1b.svg)](https://arxiv.org/abs/2506.17298)
 
+[DiffusionGemma Explained (ML@Berkeley)](https://mlberkeley.substack.com/p/the-annotated-diffusiongemma)
+
 
 [![Star History Chart](https://api.star-history.com/svg?repos=VILA-Lab/Awesome-DLMs&type=Date)](https://www.star-history.com/#VILA-Lab/Awesome-DLMs&Date)
 


### PR DESCRIPTION
Adds [DiffusionGemma Explained](https://mlberkeley.substack.com/p/the-annotated-diffusiongemma) to the Resources section — an annotated walkthrough of Google's DiffusionGemma (26B-A4B uniform-state diffusion LM), covering its architecture (scalar QK norm, partial RoPE, MoE) and stage-then-commit sampling, plus an empirical look at its denoising order. Thanks for maintaining this list!