### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1895,7 +1895,7 @@ Super Data Learners: [Diffusion Language Models are Super Data Learners](https:/
 [DiffusionGemma Explained (ML@Berkeley)](https://mlberkeley.substack.com/p/the-annotated-diffusiongemma)
 
 
-[![Star History Chart](https://api.star-history.com/svg?repos=VILA-Lab/Awesome-DLMs&type=Date)](https://www.star-history.com/#VILA-Lab/Awesome-DLMs&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=VILA-Lab/Awesome-DLMs&type=Date)](https://star-history.dera.page/#VILA-Lab/Awesome-DLMs&Date)
 
 ## Citation
 ```


### PR DESCRIPTION
The star history chart in the README is broken because it relies on the GitHub stargazer API, which has restricted access. This updates the chart link to a working endpoint so the chart displays correctly again.